### PR TITLE
[DEFECT]: parallel-ssh can timeout on long running commands

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -230,7 +230,7 @@ action :execute do
     pssh_opt="-g #{new_resource.name}"
   when "debian", "ubuntu"
     pssh_cmd="parallel-ssh"
-    pssh_opt="-h #{group_file} -p 32 -t 60"
+    pssh_opt="-h #{group_file} -p 32 -t 120"
   end
 
   def shell_escape(s)

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -230,7 +230,7 @@ action :execute do
     pssh_opt="-g #{new_resource.name}"
   when "debian", "ubuntu"
     pssh_cmd="parallel-ssh"
-    pssh_opt="-h #{group_file}"
+    pssh_opt="-h #{group_file} -p 32 -t 60"
   end
 
   def shell_escape(s)


### PR DESCRIPTION
- set default timeout to 60 seconds
- set # of parallel threads to 32
