### PR TITLE
fix hash to string type error

### DIFF
--- a/providers/dsh.rb
+++ b/providers/dsh.rb
@@ -143,8 +143,7 @@ def get_pubkey(home)
   pubkey_path = "#{privkey_path}.pub"
   if not (::File.exists? privkey_path or ::File.exists? pubkey_path)
     Chef::Log.info("Generating ssh keys for user #{new_resource.admin_user}")
-    system("su #{new_resource.admin_user} -c 'ssh-keygen -q -f #{privkey_path} " +
-           "-P \"\"'", :in=>"/dev/null")
+    system("su #{new_resource.admin_user} -c 'ssh-keygen -q -f #{privkey_path} " + "-P \"\"'")
     new_resource.updated_by_last_action(true)
   end
   pubkey = ::File.read("#{home}/.ssh/id_rsa.pub").strip


### PR DESCRIPTION
[2013-05-02T14:41:25+00:00] DEBUG: Sending HTTP Request via GET to 10.0.0.2:4000//search/node
[2013-05-02T14:41:25+00:00] DEBUG: ---- HTTP Status and Header Data: ----
[2013-05-02T14:41:25+00:00] DEBUG: HTTP 1.1 200 OK
[2013-05-02T14:41:25+00:00] DEBUG: connection: close
[2013-05-02T14:41:25+00:00] DEBUG: content-type: application/json; charset=utf-8
[2013-05-02T14:41:25+00:00] DEBUG: server: thin 1.5.1 codename Straight Razor
[2013-05-02T14:41:25+00:00] DEBUG: ---- End HTTP Status/Header Data ----
[2013-05-02T14:41:25+00:00] INFO: Generating ssh keys for user root from /root/.ssh/id_rsa and /root/.ssh/id_rsa.pub
# 

Error executing action `join` on resource 'dsh_group[swift-storage]'
# 
## TypeError

can't convert Hash into String
## Cookbook Trace:

/srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in `system'
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in`get_pubkey'
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:84:in `class_from_file'
## Resource Declaration:
# In /srv/chef/file_store/cookbooks/swift/recipes/management-server.rb

 34: 
 35: dsh_group "swift-storage" do
 36:   admin_user "root"
 37:   network "swift"
 38: end
 39: 
## Compiled Resource:
# Declared in /srv/chef/file_store/cookbooks/swift/recipes/management-server.rb:35:in `from_file'

dsh_group("swift-storage") do
  cookbook_name "swift"
  execute "sudo /etc/swift/pull-rings.sh"
  retry_delay 2
  network "swift"
  updated_by_last_action true
  retries 0
  updated true
  admin_user "root"
  recipe_name "management-server"
  action :join
end

[2013-05-02T14:41:25+00:00] DEBUG: Re-raising exception: TypeError - dsh_group[swift-storage](swift::management-server line 35) had an error: TypeError: can't convert Hash into String
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in `system'
  /srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in`get_pubkey'
  /srv/chef/file_store/cookbooks/dsh/providers/group.rb:84:in `class_from_file'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:207:in`instance_eval'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:207:in `action_join'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:123:in`send'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:123:in `run_action'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource.rb:593:in`run_action'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:49:in `run_action'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in`converge'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in `each'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in`converge'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:94:in `execute_each_resource'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in`call'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:85:in`step'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:55:in`each_with_index'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:92:in `execute_each_resource'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:80:in`converge'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:378:in `converge'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:420:in`do_run'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:176:in `run'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:283:in`run_application'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:270:in `loop'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:270:in`run_application'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application.rb:70:in `run'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/chef-client:26
  /opt/vagrant_ruby/bin/chef-client:19:in`load'
  /opt/vagrant_ruby/bin/chef-client:19
[2013-05-02T14:41:25+00:00] ERROR: Running exception handlers
[2013-05-02T14:41:25+00:00] FATAL: Saving node information to /srv/chef/file_store/failed-run-data.json
[2013-05-02T14:41:25+00:00] ERROR: Exception handlers complete
[2013-05-02T14:41:25+00:00] FATAL: Stacktrace dumped to /srv/chef/file_store/chef-stacktrace.out
[2013-05-02T14:41:25+00:00] DEBUG: TypeError: dsh_group[swift-storage](swift::management-server line 35) had an error: TypeError: can't convert Hash into String
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in `system'
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:147:in`get_pubkey'
/srv/chef/file_store/cookbooks/dsh/providers/group.rb:84:in `class_from_file'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:207:in`instance_eval'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:207:in `action_join'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:123:in`send'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:123:in `run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource.rb:593:in`run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:49:in `run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in`converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in `each'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in`converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:94:in `execute_each_resource'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in`call'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:85:in`step'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:55:in`each_with_index'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:92:in `execute_each_resource'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:80:in`converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:378:in `converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:420:in`do_run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:176:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:283:in`run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:270:in `loop'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/client.rb:270:in`run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application.rb:70:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/chef-client:26
/opt/vagrant_ruby/bin/chef-client:19:in`load'
/opt/vagrant_ruby/bin/chef-client:19
[2013-05-02T14:41:25+00:00] FATAL: TypeError: dsh_group[swift-storage](swift::management-server line 35) had an error: TypeError: can't convert Hash into String
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chef-client -c /tmp/vagrant-chef-1/client.rb -j /tmp/vagrant-chef-1/dna.json
