### PR TITLE
Fixes DE226: refactor node attribute/search logic

### DIFF
--- a/spec/group_provider_spec.rb
+++ b/spec/group_provider_spec.rb
@@ -59,7 +59,7 @@ describe "dsh::default" do
         with(:node, "dsh_admin_groups:testing AND chef_environment:#{node.chef_environment}").
         and_return(admin_group_results)
 
-      node.should_receive("save")
+      #node.should_receive("save")
     end
 
     it "installs platform packages" do


### PR DESCRIPTION
This provider had two large `if` conditionals that each set node
attributes and searched for other nodes.  The problem was that the
current node was never included in the fun first-time around (even if it
wanted to be, there was a chicken-egg problem with doing the node
searches before the current node's attributes were set).

I broke the logic into "setting attributes" and then "searching nodes
and generating file data."  I modified the search functions to include
the current node if necessary (take a hike, `run_twice`). I commented the
logic and added debugging statements. I renamed/added variables and
renamed `get_pubkey()` to `configure_pubkey()` (more accurate to its
function). Touched up a couple minor style things and trivial bugs
(eg., unnecessary call to node.save). Tested the hell out of it.
