### PR TITLE
Fixes DE240: bugfix: stale keys cannot be detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Author:: William Kelly (<william.kelly@rackspace.com>)
 Author:: Darren Birkett (<darren.birkett@rackspace.co.uk>)  
 Author:: Evan Callicoat (<evan.callicoat@rackspace.com>)  
 Author:: Chris Laco (<chris.laco@rackspace.com>)
+Author:: Brett Campbell (<brett.campbell@rackspace.com>)
 
 Copyright 2012-2013, Rackspace US, Inc.  
 

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -50,7 +50,7 @@ action :join do
   # join group by setting attributes ('user' and 'access_name').
   if new_resource.user
     Chef::Log.debug("dsh_group: i'm a member! setting user attributes")
-    node.set["dsh"]["groups"][new_resource.name] = {}
+    node.set_unless["dsh"]["groups"][new_resource.name] = {}
     node.set["dsh"]["groups"][new_resource.name]["user"] =
       get_user_name(new_resource.user)
 


### PR DESCRIPTION
don't reinitialize `node['dsh']['groups'][new_resource.name]` every time.  this breaks the code that detects stale pubkeys.
