### PR TITLE
(Re)Add :nothing to allowed_actions

### DIFF
--- a/libraries/resource_dsh_group.rb
+++ b/libraries/resource_dsh_group.rb
@@ -30,7 +30,7 @@ class Chef
         @resource_name = :dsh_group
         @provider = Chef::Provider::DshGroup
         @action = :join
-        @allowed_actions = [:execute, :join]
+        @allowed_actions = [:execute, :join, :nothing]
         @group = name
       end
 

--- a/spec/resource_dsh_group_spec.rb
+++ b/spec/resource_dsh_group_spec.rb
@@ -5,7 +5,7 @@ describe Chef::Resource::DshGroup do
 
   describe "#initialize" do
     its(:action) { should eq :join }
-    its(:allowed_actions) { should eq [:execute, :join] }
+    its(:allowed_actions) { should eq [:execute, :join, :nothing] }
     its(:provider) { should eq Chef::Provider::DshGroup }
     its(:resource_name) { should eq :dsh_group }
   end


### PR DESCRIPTION
Apparently some of the more comprehensive gates use dsh_group with the
:nothing action for delayed joins/executes. Derp.
